### PR TITLE
IL 42: create message component: check for default recipient

### DIFF
--- a/app/cards.json
+++ b/app/cards.json
@@ -90,7 +90,7 @@
       },
       "label":"Personal",
       "name":"Jeff",
-      "email":"jgraham@pdx.edu",
+      "email":"jeff@gmail.com",
       "owner":true,
       "time": 1522634927,
       "image": ""

--- a/app/components/create_message/index.js
+++ b/app/components/create_message/index.js
@@ -24,9 +24,10 @@ import {Actions} from 'react-native-router-flux';
 // CREATEMESSAGE
 // FUNCTION(S): This component displays a dropdown menu to select a message
 // recipient and a textinput box to send a message to the selected recipient.
+// If a recipient is passed in as an argument, it will be the default value in
+// the picker. Otherwise, the first card in the picker will be the default.
 //
-// FUTURE FUNCTION(S): A default card will be selected as the recipient if
-// it is passed in as a prop. The recipient dropdown menu will distinguish
+// FUTURE FUNCTION(S): The recipient dropdown menu will distinguish
 // between wallet cards and rolodex cards to display recipients correctly.
 //
 // EXPECTED PROP(S): this.props.recipient
@@ -37,7 +38,7 @@ class CreateMessage extends Component {
     constructor(props) {
         super(props);
 
-        this.state = {message: "", recipient: "", sender: ""};
+        this.state = {message: "", recipient: this.props.recipient === "" ? this.props.cards[0].id : this.props.recipient, sender: ""};
     }
 
     componentDidMount(){

--- a/app/index.js
+++ b/app/index.js
@@ -70,7 +70,7 @@ class Main extends Component{
                     <Scene key="share" component={Share} title="Share" />
                     <Scene key="message_thread" component={MessageThread} title="MessageThread" />
                     <Scene key="create_message" component={CreateMessage} title="New Message" />
-                    <Scene key="inbox" component={Inbox} title="Inbox" titleStyle={{alignSelf: 'center'}} onRight={() => Actions.create_message()} rightTitle='Message' />
+                    <Scene key="inbox" component={Inbox} title="Inbox" titleStyle={{alignSelf: 'center'}} onRight={() => Actions.create_message({recipient: ""})} rightTitle='Message' />
                     <Scene key="create_card" component={CreateCard} title="Add Information" />
                     <Scene key="login" component={Login} title="Login" />
                     <Scene key="register" component={Register} title="Register" />


### PR DESCRIPTION
- Added check for default recipient in create_message.
- If no default recipient is passed in, the component will still expect an empty string.
- When no recipient is passed in, the first card will be selected as the default.