### PR TITLE
IL-72: Make entire Wallet/Rolodex card button clickable

### DIFF
--- a/app/components/card_list/index.js
+++ b/app/components/card_list/index.js
@@ -121,18 +121,17 @@ class CardList extends Component {
                                 />
                             </TouchableOpacity>
                         </View>
-                        <View
-                            style={[styles.button, styles.cardButton, styles.cardButtonWallet]}
-                            backgroundColor={COLORS[index % COLORS.length]}
+                        <TouchableOpacity
+                            onPress={() => Actions.card_view({card: item})}
+                            onLongPress={() => this.showOptions(item)}
                         >
-                            <TouchableOpacity
-                                onPress={() => Actions.card_view({card: item})}
-                                onLongPress={() => this.showOptions(item)}
-                                style={[styles.innerButton, styles.cardButton, styles.cardButtonWallet]}
+                            <View
+                                style={[styles.button, styles.cardButton, styles.cardButtonWallet]}
+                                backgroundColor={COLORS[index % COLORS.length]}
                             >
                                 <Text>{item.label}</Text>
-                            </TouchableOpacity>
-                        </View>
+                            </View>
+                        </TouchableOpacity>
                         <View style={[styles.button, styles.gotoButton, styles.gotoButtonWallet]}>
                             <TouchableOpacity onPress={() => Actions.share({card: item})} onLongPress={() => this.showOptions(item)}>
                                 <Image
@@ -156,18 +155,17 @@ class CardList extends Component {
                                 />
                             </TouchableOpacity>
                         </View>
-                        <View
-                            style={[styles.button, styles.cardButton, styles.cardButtonRolodex]}
-                            backgroundColor={COLORS[index % COLORS.length]}
+                        <TouchableOpacity
+                            onPress={() => Actions.card_view({card: item})}
+                            onLongPress={() => this.showOptions(item)}
                         >
-                            <TouchableOpacity
-                                onPress={() => Actions.card_view({card: item})}
-                                onLongPress={() => this.showOptions(item)}
-                                style={[styles.innerButton, styles.cardButton, styles.cardButtonRolodex]}
+                            <View
+                                style={[styles.button, styles.cardButton, styles.cardButtonRolodex]}
+                                backgroundColor={COLORS[index % COLORS.length]}
                             >
                                 <Text>{item.label}</Text>
-                            </TouchableOpacity>
-                        </View>
+                            </View>
+                        </TouchableOpacity>
                         <View style={[styles.button, styles.gotoButton, styles.gotoButtonRolodex]}>
                             <TouchableOpacity onPress={() => Actions.message_thread({card: item})}>
                                 <Image

--- a/app/components/card_list/index.js
+++ b/app/components/card_list/index.js
@@ -125,7 +125,11 @@ class CardList extends Component {
                             style={[styles.button, styles.cardButton, styles.cardButtonWallet]}
                             backgroundColor={COLORS[index % COLORS.length]}
                         >
-                            <TouchableOpacity onPress={() => Actions.card_view({card: item})} onLongPress={() => this.showOptions(item)}>
+                            <TouchableOpacity
+                                onPress={() => Actions.card_view({card: item})}
+                                onLongPress={() => this.showOptions(item)}
+                                style={[styles.innerButton, styles.cardButton, styles.cardButtonWallet]}
+                            >
                                 <Text>{item.label}</Text>
                             </TouchableOpacity>
                         </View>
@@ -156,7 +160,11 @@ class CardList extends Component {
                             style={[styles.button, styles.cardButton, styles.cardButtonRolodex]}
                             backgroundColor={COLORS[index % COLORS.length]}
                         >
-                            <TouchableOpacity onPress={() => Actions.card_view({card: item})} onLongPress={() => this.showOptions(item)}>
+                            <TouchableOpacity
+                                onPress={() => Actions.card_view({card: item})}
+                                onLongPress={() => this.showOptions(item)}
+                                style={[styles.innerButton, styles.cardButton, styles.cardButtonRolodex]}
+                            >
                                 <Text>{item.label}</Text>
                             </TouchableOpacity>
                         </View>

--- a/app/components/card_list/styles.js
+++ b/app/components/card_list/styles.js
@@ -44,13 +44,6 @@ export default StyleSheet.create({
         marginTop: 6,
     },
 
-    innerButton: {
-        height: buttonHeight,
-        alignItems: 'center',
-        justifyContent: 'center',
-        borderRadius: BORDER_RADIUS
-    },
-
     topButtonText: {
         color: '#6666EE'
     },

--- a/app/components/card_list/styles.js
+++ b/app/components/card_list/styles.js
@@ -44,6 +44,13 @@ export default StyleSheet.create({
         marginTop: 6,
     },
 
+    innerButton: {
+        height: buttonHeight,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: BORDER_RADIUS
+    },
+
     topButtonText: {
         color: '#6666EE'
     },


### PR DESCRIPTION
- Added styling to TouchableOpacity components for card view buttons so that the buttons fill their entire viewing area.