### PR TITLE
IL-97: Updated display for default recipient in create message screen

### DIFF
--- a/app/components/card_list/index.js
+++ b/app/components/card_list/index.js
@@ -138,7 +138,7 @@ class CardList extends Component {
                                 </View>
                             </TouchableOpacity>
                             <View style={[styles.button, styles.gotoButton, styles.gotoButtonRolodex]}>
-                                <TouchableOpacity onPress={() => Actions.create_message({recipient: item})}>
+                                <TouchableOpacity onPress={() => Actions.create_message({sender: null, recipient: item})}>
                                     <Image
                                         style={styles.imageContainer}
                                         source={require('../../assets/mail.png')}

--- a/app/components/card_list/index.js
+++ b/app/components/card_list/index.js
@@ -138,7 +138,7 @@ class CardList extends Component {
                                 </View>
                             </TouchableOpacity>
                             <View style={[styles.button, styles.gotoButton, styles.gotoButtonRolodex]}>
-                                <TouchableOpacity onPress={() => Actions.create_message()}>
+                                <TouchableOpacity onPress={() => Actions.create_message({recipient: item})}>
                                     <Image
                                         style={styles.imageContainer}
                                         source={require('../../assets/mail.png')}

--- a/app/components/create_message/index.js
+++ b/app/components/create_message/index.js
@@ -18,27 +18,25 @@ import { Actions } from 'react-native-router-flux';
 import ActionSheet from 'react-native-actionsheet';
 
 // CREATEMESSAGE
-// FUNCTION(S): This component displays a dropdown menu to select a message
+// FUNCTION(S): This component displays a menu to select a message sender and
 // recipient and a textinput box to send a message to the selected recipient.
 // If a recipient is passed in as an argument, it will be the default value in
-// the picker. Otherwise, the first card in the picker will be the default.
-//
-// FUTURE FUNCTION(S): The recipient dropdown menu will distinguish
-// between wallet cards and rolodex cards to display recipients correctly.
+// the picker. Otherwise, no default will be set.
 //
 // EXPECTED PROP(S): this.props.recipient
 // This component will expect a recipient (a card object) to be used as the
-// default recipient selection. If an empty string is passed in instead, no
+// default recipient selection. If null is passed in instead, no
 // default recipient will be selected.
 class CreateMessage extends Component {
     constructor(props) {
         super(props);
         this.state = {
           message: "",
-          recipient: this.props.recipient,
+          recipient: this.props.recipient === null ? "" : this.props.recipient.keys.n,
           sender: "",
           senderLabel: "",
-          recipientLabel: ""
+          recipientLabel: this.props.recipient === null ?
+            "" : this.props.recipient.name + " (" + this.props.recipient.label + ")"
         };
         this.generateID = this.generateID.bind(this);
         this.generateTimestamp = this.generateTimestamp.bind(this);

--- a/app/components/create_message/index.js
+++ b/app/components/create_message/index.js
@@ -20,21 +20,19 @@ import ActionSheet from 'react-native-actionsheet';
 // CREATEMESSAGE
 // FUNCTION(S): This component displays a menu to select a message sender and
 // recipient and a textinput box to send a message to the selected recipient.
-// If a recipient is passed in as an argument, it will be the default value in
-// the picker. Otherwise, no default will be set.
 //
-// EXPECTED PROP(S): this.props.recipient
-// This component will expect a recipient (a card object) to be used as the
-// default recipient selection. If null is passed in instead, no
-// default recipient will be selected.
+// EXPECTED PROP(S): this.props.sender, this.props.recipient
+// This component will expect a sender or recipient (a card object) to be used as the
+// default selection. If null is passed in instead, no default will be selected.
 class CreateMessage extends Component {
     constructor(props) {
         super(props);
         this.state = {
           message: "",
+          sender: this.props.sender === null ? "" : this.props.sender.keys.n,
           recipient: this.props.recipient === null ? "" : this.props.recipient.keys.n,
-          sender: "",
-          senderLabel: "",
+          senderLabel: this.props.sender === null ?
+            "" : this.props.sender.name + " (" + this.props.sender.label + ")",
           recipientLabel: this.props.recipient === null ?
             "" : this.props.recipient.name + " (" + this.props.recipient.label + ")"
         };

--- a/app/index.js
+++ b/app/index.js
@@ -79,7 +79,7 @@ class Main extends Component {
                     <Scene key="message_thread" component={MessageThread} title="MessageThread" />
                     <Scene key="create_message" component={CreateMessage} title="New Message" />
                     <Scene key="inbox" component={Inbox} title="Inbox"
-                        titleStyle={styles.title} onRight={() => Actions.create_message({recipient: null})}
+                        titleStyle={styles.title} onRight={() => Actions.create_message({sender: null, recipient: null})}
                         rightTitle='Message' />
                     <Scene key="create_card" component={CreateCard} title="Add Information" 
                         />

--- a/app/index.js
+++ b/app/index.js
@@ -79,7 +79,7 @@ class Main extends Component {
                     <Scene key="message_thread" component={MessageThread} title="MessageThread" />
                     <Scene key="create_message" component={CreateMessage} title="New Message" />
                     <Scene key="inbox" component={Inbox} title="Inbox"
-                        titleStyle={styles.title} onRight={() => Actions.create_message({recipient: ""})}
+                        titleStyle={styles.title} onRight={() => Actions.create_message({recipient: null})}
                         rightTitle='Message' />
                     <Scene key="create_card" component={CreateCard} title="Add Information" 
                         />


### PR DESCRIPTION
- create_message component now correctly accepts and displays a default recipient for the new recipient selector if a card is passed in.

- When no default recipient is required, null should be passed in for the recipient prop.

- When the create message button is pressed in rolodex the corresponding card is now passed in as the recipient.

- These changes can be tested by creating a new message from inbox where no recipient should inititally be displayed and by using the create message button in rolodex for each person and seeing if their name and label are correctly displayed. Without changing the recipient from the default, a message can also be sent to ensure that the recipient's public key is being passed in correctly.