### PR TITLE
IL-106: Removed font package

### DIFF
--- a/App.js
+++ b/App.js
@@ -7,7 +7,6 @@
 import React, { Component } from 'react';
 import { Platform, AppRegistry, YellowBox } from 'react-native';
 import { Provider } from 'react-redux';
-//import { Font } from 'expo';
 import store from './app/store';
 import Main from './app/index';
 
@@ -22,11 +21,6 @@ export default class App extends Component {
     }
     
     async componentDidMount() {
-        if (Platform.OS === 'ios') {
-            await Font.loadAsync({
-                'sans-serif': require('./app/assets/fonts/sansserif.ttf'),
-            });
-        }
         this.setState({loadingFont: true});
     }
 


### PR DESCRIPTION
Removed the font package because it was using an expo package.

Testing:
Entry of the application should no longer throw a warning about missing Font module.