### PR TITLE
IL-62: Display portraits inside message_thread

### DIFF
--- a/app/components/message_thread/index.js
+++ b/app/components/message_thread/index.js
@@ -101,8 +101,10 @@ class MessageThread extends Component {
                     },
                 };
                 // User _id: 1 for application user, 2 for other party
-                if(item.from === receiver)
+                if(item.from === receiver) {
                     message.user._id = 2;
+                    message.user.avatar = this.props.pair.senderCard.image;
+                }
                 else
                     message.user._id = 1;
                 messageList.push(message);
@@ -143,7 +145,6 @@ class MessageThread extends Component {
                 user= {{
                     _id: 1,
                 }}
-                renderAvatar={null}
                 isAnimated={true}
             />
         )

--- a/app/components/message_thread/index.js
+++ b/app/components/message_thread/index.js
@@ -103,7 +103,11 @@ class MessageThread extends Component {
                 // User _id: 1 for application user, 2 for other party
                 if(item.from === receiver) {
                     message.user._id = 2;
-                    message.user.avatar = this.props.pair.senderCard.image;
+                    if(this.props.pair.senderCard.image !== null) {
+                        message.user.avatar = this.props.pair.senderCard.image;
+                    } else {
+                        message.user.avatar = portrait;
+                    }
                 }
                 else
                     message.user._id = 1;

--- a/app/components/message_thread/index.js
+++ b/app/components/message_thread/index.js
@@ -104,7 +104,7 @@ class MessageThread extends Component {
                 if(item.from === receiver) {
                     message.user._id = 2;
                     if(this.props.pair.senderCard.image !== null) {
-                        message.user.avatar = this.props.pair.senderCard.image;
+                        message.user.avatar = this.props.pair.receiverCard.image;
                     } else {
                         message.user.avatar = portrait;
                     }


### PR DESCRIPTION
# Test for IL-62
1. Open up inbox
2. Click on a message
3. Portrait of the correct user (matches inbox portrait) should appear to the left of the text

![il-62](https://user-images.githubusercontent.com/11451280/40036496-98d3aec8-57bc-11e8-822f-0acbde806690.jpg)
