### PR TITLE
IL-100: Option to go to message thread or inbox from Lockbox

### DIFF
--- a/app/components/lockbox/index.js
+++ b/app/components/lockbox/index.js
@@ -72,9 +72,9 @@ class Lockbox extends Component {
             console.log('message object:', jsonStringP)
             // add it to messages!
             this.props.addMessage(jsonStringP);
-            // send user to home screen
+            // send user to inbox view
             Actions.pop();
-            Actions.home();
+            Actions.inbox();
         }
         else {
             // TODO: add error handling alert user can't decrypt message


### PR DESCRIPTION
Testing notes:
Send message from new message thread goes to inbox.
Also decrypt a message, notice it will go to inbox view now. 

I tried to implement going directly to message thread but it's proved complicated to do because we now pass the entire card objects into message thread we often don't have these objects handy in the lockbox component. Also it'd defeat the utility in having read true/false functionality if we went to message thread directly after deencryption.