### PR TITLE
IL-117: Prevent user from decrypting same message twice

### DIFF
--- a/app/components/lockbox/index.js
+++ b/app/components/lockbox/index.js
@@ -59,27 +59,43 @@ export class Lockbox extends Component {
                 break;
             }
         }
-        if (cardMatch) {
-            console.log('card match key output:', cardMatch.keys)
-            var jsond = JSON.stringify(cardMatch.keys)
-            rsa.setPrivateString(jsond);
-            console.log('the cyperedtext string is:',jsonStringP.body)
-            console.log('the private key is:',jsond)
-            var decrypted = rsa.decrypt(jsonStringP.body); // decrypted == originText
-            console.log('the cyper says:',decrypted)
-            //replace json encrypted text with decrypted text
-            jsonStringP.body = decrypted
-            console.log('message object:', jsonStringP)
-            // add it to messages!
-            this.props.addMessage(jsonStringP);
-            // send user to inbox view
-            Actions.pop();
-            Actions.inbox();
+
+        var notDuplicateMessage = true;
+        for (var i = 0, len = this.props.messages.length; i < len; i++) {
+            console.log('iterating through messages!', i)
+            if(this.props.messages[i].id === jsonStringP.id){
+                notDuplicateMessage = false;
+                break;
+            }
         }
-        else {
-            // TODO: add error handling alert user can't decrypt message
-            console.log("couldnt find a matching public key in users cards")
-            Actions.pop();
+
+        if(notDuplicateMessage){
+            if (cardMatch) {
+                console.log('card match key output:', cardMatch.keys)
+                var jsond = JSON.stringify(cardMatch.keys)
+                rsa.setPrivateString(jsond);
+                console.log('the cyperedtext string is:',jsonStringP.body)
+                console.log('the private key is:',jsond)
+                var decrypted = rsa.decrypt(jsonStringP.body); // decrypted == originText
+                console.log('the cyper says:',decrypted)
+                //replace json encrypted text with decrypted text
+                jsonStringP.body = decrypted
+                console.log('message object:', jsonStringP)
+                // add it to messages!
+                this.props.addMessage(jsonStringP);
+                // send user to inbox view
+                Actions.pop();
+                Actions.inbox();
+            }
+            else {
+                // TODO: add error handling alert user can't decrypt message
+                console.log("couldnt find a matching public key in users cards")
+                Actions.home();
+            }
+        }
+        else{
+            alert("You have already decrypted this message! Check your inbox.");
+            Actions.inbox();
         }
     }
 

--- a/app/components/lockbox/index.js
+++ b/app/components/lockbox/index.js
@@ -95,7 +95,8 @@ export class Lockbox extends Component {
         }
         else{
             alert("You have already decrypted this message! Check your inbox.");
-            Actions.inbox();
+                Actions.pop();
+                Actions.inbox();
         }
     }
 

--- a/app/components/splash/index.js
+++ b/app/components/splash/index.js
@@ -32,17 +32,13 @@ export class Splash extends Component {
         Linking.getInitialURL().then(url => {
           this.navigate(url);
         });
-        } else {
-            Linking.addEventListener('url', this.handleOpenURL);
         }
-    }
-
-    componentWillUnmount() {
-        Linking.removeEventListener('url', this.handleOpenURL);
-    }
-
-    handleOpenURL = (event) => {
-        this.navigate(event.url);
+        else{
+            this.startAnimation();
+            setTimeout(() => {
+                this.props.navigation.navigate('home');
+            }, (DEBUG ? 0 : 4000));
+        }
     }
 
     navigate = (url) => {

--- a/app/components/splash/index.js
+++ b/app/components/splash/index.js
@@ -7,14 +7,14 @@
 import React, { Component } from 'react';
 import { Text, View, StyleSheet,
         Animated, Easing, 
-        Image } from 'react-native';
+        Image, Platform, Linking } from 'react-native';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as ReduxActions from '../../actions';
 import { Actions } from 'react-native-router-flux';
 import styles from './styles';
 
-const DEBUG = true;
+const DEBUG = treu;
 
 export class Splash extends Component {
     static navigationOptions = {
@@ -24,13 +24,43 @@ export class Splash extends Component {
     constructor(props) {
         super();
         this.fade_in = new Animated.Value(0);
+        this.state = {deeplink: false}
     };
     
     componentDidMount() {
-        this.startAnimation();
-        setTimeout(() => {
-            this.props.navigation.navigate('home');
-        }, (DEBUG ? 0 : 4000));
+        if (Platform.OS === 'android') {
+        Linking.getInitialURL().then(url => {
+          this.navigate(url);
+        });
+        } else {
+            Linking.addEventListener('url', this.handleOpenURL);
+        }
+    }
+
+    componentWillUnmount() {
+        Linking.removeEventListener('url', this.handleOpenURL);
+    }
+
+    handleOpenURL = (event) => {
+        this.navigate(event.url);
+    }
+
+    navigate = (url) => {
+        //if there is no deep link the display splash screen
+        if(!url){
+            this.startAnimation();
+            setTimeout(() => {
+                this.props.navigation.navigate('home');
+            }, (DEBUG ? 0 : 4000));
+        }
+        const route = url.replace(/.*?:\/\//g, '');
+        let id = 'empty';
+        id = route.match(/\/([^\/]+)\/?$/)[1];
+        const routeName = route.split('/')[0];
+        if (routeName === 'lockbox') {
+            this.setState({deeplink: true})
+            Actions.lockbox({title:"Decrypt Message", mode: "decrypt", message: id})
+        }
     }
 
     startAnimation = () => {

--- a/app/components/splash/index.js
+++ b/app/components/splash/index.js
@@ -14,7 +14,7 @@ import * as ReduxActions from '../../actions';
 import { Actions } from 'react-native-router-flux';
 import styles from './styles';
 
-const DEBUG = treu;
+const DEBUG = true;
 
 export class Splash extends Component {
     static navigationOptions = {

--- a/app/components/splash/index.js
+++ b/app/components/splash/index.js
@@ -24,7 +24,7 @@ export class Splash extends Component {
     constructor(props) {
         super();
         this.fade_in = new Animated.Value(0);
-        this.state = {deeplink: false}
+        this.state = {}
     };
     
     componentDidMount() {
@@ -42,7 +42,7 @@ export class Splash extends Component {
     }
 
     navigate = (url) => {
-        //if there is no deep link the display splash screen
+        //if there is no deep link on android the display splash screen
         if(!url){
             this.startAnimation();
             setTimeout(() => {
@@ -54,7 +54,6 @@ export class Splash extends Component {
         id = route.match(/\/([^\/]+)\/?$/)[1];
         const routeName = route.split('/')[0];
         if (routeName === 'lockbox') {
-            this.setState({deeplink: true})
             Actions.lockbox({title:"Decrypt Message", mode: "decrypt", message: id})
         }
     }

--- a/app/index.js
+++ b/app/index.js
@@ -154,18 +154,42 @@ class Main extends Component {
             }
         });
 
-    }
-    
-    _backAndroidHandler = () => {
-        const scene = Actions.currentScene;
-        // alert(scene)
-        if (scene === 'index' || scene === 'home' || scene === 'main') {
-            BackHandler.exitApp();
-            return true;
-        }
-        Actions.pop();
-        return true;
-    };
+        if (Platform.OS !== 'android') {
+            Linking.addEventListener('url', this.handleOpenURL);
+          }
+  
+      }
+      componentWillUnmount() {
+          Linking.removeEventListener('url', this.handleOpenURL);
+      }
+  
+      handleOpenURL = (event) => {
+          this.navigate(event.url);
+      }
+      
+      _backAndroidHandler = () => {
+          const scene = Actions.currentScene;
+          // alert(scene)
+          if (scene === 'index' || scene === 'home' || scene === 'main') {
+              BackHandler.exitApp();
+              return true;
+          }
+          Actions.pop();
+          return true;
+      };
+  
+      navigate = (url) => {
+          //const { navigate } = this.props.navigation;
+          
+          const route = url.replace(/.*?:\/\//g, '');
+          let id = 'empty';
+          id = route.match(/\/([^\/]+)\/?$/)[1];
+          const routeName = route.split('/')[0];
+          if (routeName === 'lockbox') {
+            Actions.lockbox({title:"Decrypt Message", mode: "decrypt", message: id})
+          };
+      }
+  
 
     render() {
         return (

--- a/app/index.js
+++ b/app/index.js
@@ -154,21 +154,6 @@ class Main extends Component {
             }
         });
 
-        if (Platform.OS === 'android') {
-          Linking.getInitialURL().then(url => {
-            this.navigate(url);
-          });
-        } else {
-          Linking.addEventListener('url', this.handleOpenURL);
-        }
-
-    }
-    componentWillUnmount() {
-        Linking.removeEventListener('url', this.handleOpenURL);
-    }
-
-    handleOpenURL = (event) => {
-        this.navigate(event.url);
     }
     
     _backAndroidHandler = () => {
@@ -182,19 +167,6 @@ class Main extends Component {
         return true;
     };
 
-    navigate = (url) => {
-        //const { navigate } = this.props.navigation;
-        
-        const route = url.replace(/.*?:\/\//g, '');
-        let id = 'empty';
-        id = route.match(/\/([^\/]+)\/?$/)[1];
-        const routeName = route.split('/')[0];
-        if (routeName === 'lockbox') {
-          Actions.lockbox({title:"Decrypt Message", mode: "decrypt", message: id})
-        };
-    }
-
-
     render() {
         return (
             <Router backAndroidHandler={this._backAndroidHandler} 
@@ -204,11 +176,11 @@ class Main extends Component {
                 rightButtonTextStyle={styles.subtitle}>
                 <Scene key="root">
                     <Scene key="splash" component={Splash} initial={true}/>
-                    <Scene key="home" component={Home} title="Home"
+                    <Scene key="home" component={Home} title="Home" 
                         panHandlers={null} hideNavBar type={ActionConst.RESET}
                     />
                     <Scene key="scan" component={Scan} title="Scan" />
-                    <Scene key="lockbox" component={Lockbox} title="Lockbox" />
+                    <Scene key="lockbox" component={Lockbox} title="Lockbox"/>
                     <Scene key="rolodex" component={CardList}title="Rolodex"
                         onRight={() => Actions.scan()}
                         rightButtonImage={require('./assets/add_person.png')}
@@ -229,7 +201,7 @@ class Main extends Component {
                     <Scene key="login" component={Login} title="Login" />
                     <Scene key="register" component={Register} title="Register" />
                     <Scene key="about" component={About} title="About" />
-                  </Scene>
+                </Scene>
             </Router>
         );
     }

--- a/app/index.js
+++ b/app/index.js
@@ -180,7 +180,7 @@ class Main extends Component {
                         panHandlers={null} hideNavBar type={ActionConst.RESET}
                     />
                     <Scene key="scan" component={Scan} title="Scan" />
-                    <Scene key="lockbox" component={Lockbox} title="Lockbox"/>
+                    <Scene key="lockbox" component={Lockbox} title="Lockbox" />
                     <Scene key="rolodex" component={CardList}title="Rolodex"
                         onRight={() => Actions.scan()}
                         rightButtonImage={require('./assets/add_person.png')}

--- a/app/index.js
+++ b/app/index.js
@@ -154,10 +154,13 @@ class Main extends Component {
             }
         });
 
-        if (Platform.OS !== 'android') {
+        if (Platform.OS === 'android') {
+            Linking.getInitialURL().then(url => {
+              this.navigate(url);
+            });
+          } else {
             Linking.addEventListener('url', this.handleOpenURL);
           }
-  
       }
       componentWillUnmount() {
           Linking.removeEventListener('url', this.handleOpenURL);


### PR DESCRIPTION
I added in IL-129, the bugfix for android deep linking since the fix is necessary to test this on android. The bug seemed to be caused because when clicking on the deep link the splash screen component is called, but the lockbox displays instead. It disappears because the splash screen navigates to home. 

To test:
1. Turn the splash screen on by setting `DEBUG` to false. 
2. Ensure the splash screen appears when it should. 
3. Create a card and email it to yourself. Open click the link in the email and click decrypt. You should get a notification saying you already have that message. 
4. Modify the id field of the card json you just emailed and click the new modified link. You should be returned home and there should be a message in the log saying "couldnt find a matching public key in users cards".
5. Make sure deep linking works correctly in all cases.