### PR TITLE
IL-132: Pressing the input box does not allow you to go back out to select sender/recipient in create_message

### DIFF
--- a/app/components/create_message/index.js
+++ b/app/components/create_message/index.js
@@ -17,7 +17,7 @@ import * as ReduxActions from '../../actions';
 import { Actions } from 'react-native-router-flux';
 import ActionSheet from 'react-native-actionsheet';
 
-const keyboardVerticalOffset = Platform.OS === 'ios' ? 110 : 70;
+const keyboardVerticalOffset = Platform.OS === 'ios' ? 70 : 70;
 
 // CREATEMESSAGE
 // FUNCTION(S): This component displays a menu to select a message sender and

--- a/app/components/create_message/index.js
+++ b/app/components/create_message/index.js
@@ -6,7 +6,7 @@
 //Import Libraries
 import KeyboardSpacer from 'react-native-keyboard-spacer';
 import React, { Component } from 'react';
-import { Alert, StyleSheet, FlatList,
+import { Alert, StyleSheet, FlatList, Keyboard,
         View, Text, TextInput, Platform,
         TouchableHighlight, TouchableOpacity,
         Image, KeyboardAvoidingView } from 'react-native';
@@ -148,7 +148,11 @@ export class CreateMessage extends Component {
                         onPress={(index) => this.updateRecipient(index, idTo[index], labelsTo[index])}
                     />
                 </View>
-                <View style={[styles.itemContainer, styles.bottomContainer]}>
+                <TouchableOpacity
+                    style={[styles.itemContainer, styles.bottomContainer]}
+                    activeOpacity={1}
+                    onPress={Keyboard.dismiss}
+                >
                     <View style={styles.messageBox}>
                         <TextInput
                             ref={input => {this.messageInput = input}}
@@ -167,7 +171,7 @@ export class CreateMessage extends Component {
                             />
                         </TouchableOpacity>
                     </View>
-                </View>
+                </TouchableOpacity>
             </KeyboardAvoidingView>
         );
     }

--- a/app/components/create_message/styles.js
+++ b/app/components/create_message/styles.js
@@ -30,10 +30,10 @@ export default StyleSheet.create({
     },
 
     bottomContainer: {
-        height: screenHeight*0.78,
+        height: screenHeight*0.63,
         alignItems: 'center',
         justifyContent: 'flex-end',
-        paddingTop: screenHeight*0.78*0.4
+        paddingTop: screenHeight*0.63*0.4
     },
 
     button: {
@@ -47,7 +47,6 @@ export default StyleSheet.create({
         width: boxWidth,
         maxHeight: boxHeight,
         marginTop: screenHeight * 0.3,
-        marginBottom: screenHeight * 0.15,
         marginRight: screenWidth * 0.01,
         marginLeft: screenWidth * 0.1,
         borderLeftWidth: boxBorderWidth,
@@ -70,8 +69,7 @@ export default StyleSheet.create({
         backgroundColor: BACKGROUND_COLOR,
         marginLeft: screenWidth * 0.02,
         marginRight: screenWidth * 0.03,
-        marginTop: screenHeight * 0.2,
-        marginBottom: screenHeight * 0.05,
+        marginTop: screenHeight * 0.3
     },
 
     imageContainer: {


### PR DESCRIPTION
- Touching outside of the text input box in create_message should now dismiss the keyboard.

Testing:

1. Go to create message screen.
2. Tap text input box to bring up keyboard.
3. Type text in box and tap elsewhere on the screen. The keyboard should be dismissed.
4. Ensure other functionality is unaffected by selecting a recipient and sender and sending the message.