### PR TITLE
Bug fix: Can't view all attributes for cards with too many attributes

### DIFF
--- a/app/components/card_view/index.js
+++ b/app/components/card_view/index.js
@@ -5,8 +5,8 @@
 
 //Import Libraries
 import React, { Component } from 'react';
-import { StyleSheet, View, 
-        Text, Image, Alert } from 'react-native';
+import { StyleSheet, View,
+        Text, Image, Alert, ScrollView } from 'react-native';
 import styles from './styles';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -62,27 +62,29 @@ export class CardView extends Component {
             //displays card with no option to set default card
             return (
                 <View style={styles.container}>
-                    <Text style={styles.header}>
-                        {this.props.card.label}
-                    </Text>
-                    <View style={styles.cardPosition}>
-                        <Avatar
-                            xlarge
-                            rounded
-                            source = {icon}
-                        />
-                    </View>
-                    <View style={styles.row}>
-                        <Text style={styles.name}>
-                            Name: {this.props.card.name}
+                    <ScrollView>
+                        <Text style={styles.header}>
+                            {this.props.card.label}
                         </Text>
-                        <Text style={styles.name}>
-                            Email: {this.props.card.email}
-                        </Text>
-                        <Text style={styles.name}>
-                            {cardFields}
-                        </Text>
-                    </View>
+                        <View style={styles.cardPosition}>
+                            <Avatar
+                                xlarge
+                                rounded
+                                source = {icon}
+                            />
+                        </View>
+                        <View>
+                            <Text style={styles.name}>
+                                Name: {this.props.card.name}
+                            </Text>
+                            <Text style={styles.name}>
+                                Email: {this.props.card.email}
+                            </Text>
+                            <Text style={styles.name}>
+                                {cardFields}
+                            </Text>
+                        </View>
+                    </ScrollView>
                     <View style={styles.buttonContainer}>
                         <Button 
                             title="Share"
@@ -102,27 +104,29 @@ export class CardView extends Component {
             //displays card with option to set the default card
             return (
                 <View style={styles.container}>
-                    <Text style={styles.header}>
-                        {this.props.card.label}
-                    </Text>
-                    <View style={styles.cardPosition}>
-                        <Avatar
-                            xlarge
-                            rounded
-                            source = {icon}
-                        />
-                    </View>
-                    <View style={styles.row}>
-                        <Text style={styles.name}>
-                            Name: {this.props.card.name}
+                    <ScrollView>
+                        <Text style={styles.header}>
+                            {this.props.card.label}
                         </Text>
-                        <Text style={styles.name}>
-                            Email: {this.props.card.email}
-                        </Text>
-                        <Text style={styles.name}>
-                            {cardFields}
-                        </Text>
-                    </View>
+                        <View style={styles.cardPosition}>
+                            <Avatar
+                                xlarge
+                                rounded
+                                source = {icon}
+                            />
+                        </View>
+                        <View>
+                            <Text style={styles.name}>
+                                Name: {this.props.card.name}
+                            </Text>
+                            <Text style={styles.name}>
+                                Email: {this.props.card.email}
+                            </Text>
+                            <Text style={styles.name}>
+                                {cardFields}
+                            </Text>
+                        </View>
+                    </ScrollView>
                     <View style={styles.buttonContainer}>
                         <Button 
                             title="Share"

--- a/app/components/card_view/styles.js
+++ b/app/components/card_view/styles.js
@@ -12,17 +12,13 @@ export default StyleSheet.create({
     },
 
     buttonContainer:{
-        flex:1,
+        flex:0,
         flexDirection: 'row',
         justifyContent: 'space-around',
-        marginTop: 10,
-        backgroundColor: BACKGROUND_COLOR
-    },
-
-    row:{
-        borderBottomWidth: BORDER_WIDTH,
+        backgroundColor: BACKGROUND_COLOR,
+        borderTopWidth: BORDER_WIDTH,
         borderColor: "#ccc",
-        padding: 10
+        paddingTop: 10
     },
 
     header:{


### PR DESCRIPTION
- Fixes a bug in the card_view component where having too many attributes on a card prevented attributes and the bottom buttons from being displayed.
- The buttons are now displayed at the bottom of the card_view screen no matter the size of the card.
- A scroll view has been added to the card portion of the display to account for cards with many attributes.

Testing:

1. Create two cards: one with several user created attributes (about 5-7) and one with fewer than 5.
2. Navigate to the card_view screen for each of the two cards.
3. Ensure that the card with fewer attributes displays correctly.
4. Ensure that the card with more attributes is scrollable.
5. Ensure that the buttons are in the same position in both cases.