### PR TITLE
IL-151: Ensure about page contains proper license credits

### DIFF
--- a/app/components/about/index.js
+++ b/app/components/about/index.js
@@ -45,6 +45,13 @@ export class About extends Component {
                         Powered by id.ly team, MIT license.
                     </Text>
                 </View>
+                <View>
+                    <Text style={styles.words}
+                          onPress={() => Linking.openURL('http://underdark.io')}
+                    >
+                        Bluetooth and Wifi React Native Module by:{"\n"}http://underdark.io
+                    </Text>
+                </View>
             </View>
         );
     }

--- a/app/components/about/styles.js
+++ b/app/components/about/styles.js
@@ -38,5 +38,6 @@ export default StyleSheet.create({
     words: {
         color: '#909090',
         paddingBottom: 20,
+        textAlign: 'center'
     }
 });


### PR DESCRIPTION
## Patch Notes
* Added credits for Underdark's Bluetooth Cross-platform module with a link to their website in About
* Text now center aligned in About
## Test
Check about and it should include the link with credits